### PR TITLE
Preflight

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -18,3 +18,7 @@ insert_final_newline = true
 
 [*.md]
 trim_trailing_whitespace = false
+
+
+[*.yml]
+indent_size = 2

--- a/.github/changelog.hbs
+++ b/.github/changelog.hbs
@@ -1,0 +1,39 @@
+### Changelog
+
+{{#each releases}}
+  {{#if href}}
+    ###{{#unless major}}#{{/unless}} [{{title}}]({{href}})
+  {{else}}
+    #### {{title}}
+  {{/if}}
+
+  {{#if tag}}
+    > {{niceDate}}
+  {{/if}}
+
+  {{#if summary}}
+    {{summary}}
+  {{/if}}
+
+  {{#if fixes}}
+  Fixes:
+  {{#each fixes}}
+    - {{#if commit.breaking}}**Breaking change:** {{/if}}{{commit.subject}} {{#each fixes}}#{{id}} {{/each}}
+  {{/each}}
+  {{/if}}
+
+  {{#if commits}}
+  Commits:
+  {{#each commits}}
+    - {{#if breaking}}**Breaking change:** {{/if}}{{subject}}{{#if href}} [`{{shorthash}}`]({{href}}){{/if}}
+  {{/each}}
+  {{/if}}
+
+  {{#if merges}}
+  PRs:
+  {{#each merges}}
+    - #{{id}} {{#if commit.breaking}}**Breaking change:** {{/if}}{{message}}
+  {{/each}}
+  {{/if}}
+
+{{/each}}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.build.outputs.version }}
     steps:
     - uses: actions/checkout@v2
       with:
@@ -15,17 +17,16 @@ jobs:
       uses: actions/setup-node@v1
       with:
         node-version: '14.x' # You might need to adjust this value to your own version
-    # Get the version number and put it in a variable
-    - name: Get Version
-      id: version
-      run: |
-        echo "::set-output name=tag::$(git describe --abbrev=0)"
     # Build the plugin
     - name: Build
       id: build
       run: |
         npm install
         npm run build --if-present
+        version=$(git describe --abbrev=0)
+        npx auto-changelog --stdout --hide-credit --hide-empty-releases --template .github/changelog.hbs -v ${version} --starting-version ${version} > release-notes.md
+        echo "::set-output name=version::${version}"
+
     # Package the required files into a zip
     - name: Package
       run: |
@@ -41,7 +42,8 @@ jobs:
         VERSION: ${{ github.ref }}
       with:
         tag_name: ${{ github.ref }}
-        release_name: ${{ github.ref }}
+        release_name: Release ${{ github.ref }}
+        body_path: ./release-notes.md
         draft: false
         prerelease: false
     # Upload the packaged release file
@@ -53,7 +55,7 @@ jobs:
       with:
         upload_url: ${{ steps.create_release.outputs.upload_url }}
         asset_path: ./${{ github.event.repository.name }}.zip
-        asset_name: ${{ github.event.repository.name }}.zip
+        asset_name: ${{ github.event.repository.name }}-${{ steps.build.outputs.version }}.zip
         asset_content_type: application/zip
     # Upload the main.js
     - name: Upload main.js
@@ -74,7 +76,7 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: manifest.json
+        asset_path: ./manifest.json
         asset_name: manifest.json
         asset_content_type: application/json
     # Upload the style.css
@@ -88,3 +90,20 @@ jobs:
     #     asset_path: ./styles.css
     #     asset_name: styles.css
     #     asset_content_type: text/css
+  brat:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        ref: main
+    - env:
+        VERSION: ${{needs.build.outputs.version}}
+      run: |
+        echo $VERSION
+        sed -i 's|\(version":\) "[0-9\.]*"|\1 "'$VERSION'"|' manifest-beta.json
+        git config user.name github-actions
+        git config user.email github-actions@github.com
+        git add .
+        git commit -m "🔨 brat release $VERSION"
+        git push

--- a/manifest-beta.json
+++ b/manifest-beta.json
@@ -1,0 +1,10 @@
+{
+	"id": "obsidian-task-collector",
+	"name": "Task Collector (TC)",
+	"version": "0.6.2",
+	"minAppVersion": "0.13.10",
+	"description": "Manage completed tasks within a document",
+	"author": "ebullient",
+	"authorUrl": "https://github.com/ebullient",
+	"isDesktopOnly": false
+}

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "build": "node esbuild.config.mjs production",
     "pretest": "eslint --ignore-path .gitignore src/",
     "test": "jest",
-    "version": "auto-changelog -p && git add CHANGELOG.md"
+    "version": "auto-changelog -p --ignore-commit-pattern \\(changelog.*\\|Merge.*\\) && git add CHANGELOG.md"
   },
   "keywords": [
     "obsidian",

--- a/src/taskcollector-Plugin.ts
+++ b/src/taskcollector-Plugin.ts
@@ -50,17 +50,23 @@ export class TaskCollectorPlugin extends Plugin {
             id: "task-collector-mark-all-done",
             name: "Complete all tasks",
             icon: "tc-complete-all-items",
-            editorCallback: (editor: Editor, view: MarkdownView) => {
-                this.taskCollector.markAllTasks(editor, 'x');
-            }
+            callback: async () => {
+                const activeFile = this.app.workspace.getActiveFile();
+                const source = await this.app.vault.read(activeFile);
+                const result = this.taskCollector.markAllTasks(source, 'x');
+                this.app.vault.modify(activeFile, result);
+        }
         };
 
         const clearAllTasksCommand: Command = {
             id: "task-collector-clear-all-items",
             name: "Reset all completed tasks",
             icon: "tc-clear-all-items",
-            editorCallback: (editor: Editor, view: MarkdownView) => {
-                this.taskCollector.resetAllTasks(editor);
+            callback: async () => {
+                const activeFile = this.app.workspace.getActiveFile();
+                const source = await this.app.vault.read(activeFile);
+                const result = this.taskCollector.resetAllTasks(source);
+                this.app.vault.modify(activeFile, result);
             }
         };
 
@@ -68,8 +74,11 @@ export class TaskCollectorPlugin extends Plugin {
             id: "task-collector-move-completed-tasks",
             name: "Move all completed tasks to configured heading",
             icon: "tc-move-all-checked-items",
-            editorCallback: async (editor: Editor, view: MarkdownView) => {
-                this.taskCollector.moveCompletedTasksInFile(editor);
+            callback: async () => {
+                const activeFile = this.app.workspace.getActiveFile();
+                const source = await this.app.vault.read(activeFile);
+                const result = this.taskCollector.moveCompletedTasksInFile(source);
+                this.app.vault.modify(activeFile, result);
             },
         };
 

--- a/src/taskcollector-Plugin.ts
+++ b/src/taskcollector-Plugin.ts
@@ -7,7 +7,7 @@ export class TaskCollectorPlugin extends Plugin {
     taskCollector: TaskCollector;
 
     async onload(): Promise<void> {
-        console.log('loading Task Collector (TC): %o', this.app);
+        console.log('loading Task Collector (TC)');
         this.taskCollector = new TaskCollector(this.app);
         this.addSettingTab(new TaskCollectorSettingsTab(this.app, this, this.taskCollector));
         await this.loadSettings();

--- a/src/taskcollector-SettingsTab.ts
+++ b/src/taskcollector-SettingsTab.ts
@@ -21,7 +21,6 @@ export class TaskCollectorSettingsTab extends PluginSettingTab {
         containerEl.createEl("h1", { text: "Task Collector" });
 
         const tempSettings: TaskCollectorSettings = Object.assign(this.taskCollector.settings);
-        console.log("Displaying task collector settings: %o ==> %o", this.taskCollector.settings, tempSettings);
 
         new Setting(containerEl)
             .setName("Support canceled tasks")

--- a/src/taskcollector-TaskCollector.ts
+++ b/src/taskcollector-TaskCollector.ts
@@ -235,7 +235,6 @@ export class TaskCollector {
                 remaining.push("%%%COMPLETED_ITEMS_GO_HERE%%%");
             } else {
                 const taskMatch = line.match(/^(\s*)- \[(.)\]/);
-                // console.log(taskMatch);
                 if (this.isCompletedTask(taskMatch)) {
                     if (this.settings.completedAreaRemoveCheckbox) {
                         line = line.replace(this.stripTask, '$1 $2')
@@ -250,8 +249,6 @@ export class TaskCollector {
                 }
             }
         }
-        // console.log("Source lines: %o; Completed item index: %o; Completed section: %o; New tasks: %o",
-        //     remaining, completedItemsIndex, completedSection, newTasks);
 
         let result = remaining.slice(0, completedItemsIndex).concat(...newTasks).concat(...completedSection);
         if (completedItemsIndex < remaining.length - 1) {

--- a/src/taskcollector-TaskCollector.ts
+++ b/src/taskcollector-TaskCollector.ts
@@ -5,9 +5,11 @@ export class TaskCollector {
     settings: TaskCollectorSettings;
     initSettings: CompiledTasksSettings;
     completedOrCanceled: RegExp;
+    stripTask: RegExp;
 
     constructor(private app: App) {
         this.completedOrCanceled = new RegExp(/^(\s*- \[)[xX-](\] .*)$/);
+        this.stripTask = new RegExp(/^(\s*-) \[[xX-]\] (.*)$/);
     }
 
     updateSettings(settings: TaskCollectorSettings): void {
@@ -80,6 +82,10 @@ export class TaskCollector {
             : new RegExp(/^(\s*- \[) (\] .*)$/);
     }
 
+    removeCheckboxFromLine(lineText: string): string {
+        return lineText.replace(this.stripTask, '$1 $2')
+    }
+
     updateTaskLine(lineText: string, mark: string): string {
         let marked = lineText.replace(this.initSettings.incompleteTaskRegExp, '$1' + mark + '$2');
         if (this.initSettings.removeRegExp) {
@@ -124,8 +130,7 @@ export class TaskCollector {
         }
     }
 
-    markAllTasks(editor: Editor, mark: string): void {
-        const source = editor.getValue();
+    markAllTasks(source: string, mark: string): string {
         const lines = source.split("\n");
         const result: string[] = [];
 
@@ -136,7 +141,7 @@ export class TaskCollector {
                 result.push(line);
             }
         }
-        editor.setValue(result.join("\n"));
+        return result.join("\n");
     }
 
     resetTaskLine(lineText: string): string {
@@ -174,9 +179,8 @@ export class TaskCollector {
         }
     }
 
-    resetAllTasks(editor: Editor): void {
+    resetAllTasks(source: string): string {
         const LOG_HEADING = this.settings.completedAreaHeader || '## Log';
-        const source = editor.getValue();
         const lines = source.split("\n");
 
         const result: string[] = [];
@@ -196,17 +200,11 @@ export class TaskCollector {
                 result.push(line);
             }
         }
-        editor.setValue(result.join("\n"));
+        return result.join("\n");
     }
 
-    removeCheckboxFromLine(line: string): string {
-        const lineWithoutCheckbox = line.replace(/(?<=([-] ))\[.\] /, '');
-        return lineWithoutCheckbox;
-    }
-
-    moveCompletedTasksInFile(editor: Editor): void {
+    moveCompletedTasksInFile(source: string): string {
         const LOG_HEADING = this.settings.completedAreaHeader || '## Log';
-        const source = editor.getValue();
         const lines = source.split("\n");
 
         if (!source.contains(LOG_HEADING)) {
@@ -240,7 +238,7 @@ export class TaskCollector {
                 // console.log(taskMatch);
                 if (this.isCompletedTask(taskMatch)) {
                     if (this.settings.completedAreaRemoveCheckbox) {
-                        line = this.removeCheckboxFromLine(line);
+                        line = line.replace(this.stripTask, '$1 $2')
                     }
                     inTask = true;
                     newTasks.push(line);
@@ -259,7 +257,7 @@ export class TaskCollector {
         if (completedItemsIndex < remaining.length - 1) {
             result = result.concat(remaining.slice(completedItemsIndex + 1));
         }
-        editor.setValue(result.join("\n"));
+        return result.join("\n");
     }
 
     isCompletedTask(taskMatch: RegExpMatchArray): boolean {

--- a/test/generatedRegExp.test.ts
+++ b/test/generatedRegExp.test.ts
@@ -169,7 +169,6 @@ describe('Set an append date', () => {
         expect('- [x] 2021-10-06 something else').not.toMatch(tc.initSettings.resetRegExp);
 
         const completed = tc.updateTaskLine('- [ ] something #todo', 'x');
-        console.log(completed);
         expect(completed).toMatch(tc.initSettings.resetRegExp);
         expect('- [ ] something #todo ').toEqual(tc.resetTaskLine(completed));
     });

--- a/test/generatedRegExp.test.ts
+++ b/test/generatedRegExp.test.ts
@@ -179,13 +179,13 @@ describe('Set an append date', () => {
         config.completedAreaRemoveCheckbox = true;
         tc.updateSettings(config);
 
-        const lineWithCompletedTask = '- [x] something'
-        const lineWithCancledTask = '- [-] something'
-        const lineIncompletedTask = '- [ ] something'
+        const lineWithCompletedTask = '- [x] something';
+        const lineWithCancledTask = '- [-] something';
+        const lineIncompletedTask = '- [ ] something'; // not a complete/canceled task
         const lineWithoutCheckbox = '- something';
         expect(tc.removeCheckboxFromLine(lineWithCompletedTask)).toEqual(lineWithoutCheckbox);
         expect(tc.removeCheckboxFromLine(lineWithCancledTask)).toEqual(lineWithoutCheckbox);
-        expect(tc.removeCheckboxFromLine(lineIncompletedTask)).toEqual(lineWithoutCheckbox);
+        expect(tc.removeCheckboxFromLine(lineIncompletedTask)).toEqual(lineIncompletedTask); // unchanged
 
     });
 });


### PR DESCRIPTION
- Handle moment formats containing `[]`. This should fix observed issues using dataview-friendly annotations. See: https://github.com/blacksmithgu/obsidian-dataview/discussions/681

- Commands that mark _all_ tasks can now work in edit mode. This is a first step for #8 and #16.

