### PR TITLE
🐛 Cope with empty incomplete tasks setting

### DIFF
--- a/src/taskcollector-TaskCollector.ts
+++ b/src/taskcollector-TaskCollector.ts
@@ -81,6 +81,11 @@ export class TaskCollector {
             ? "xX-"
             : "xX";
 
+        let incompletedTasks = this.settings.incompleteTaskValues;
+        if (this.settings.incompleteTaskValues.indexOf(" ") < 0) {
+            incompletedTasks = " " + this.settings.incompleteTaskValues;
+        }
+
         const rightClickTaskMenu =
             this.settings.rightClickComplete ||
             this.settings.rightClickMark ||
@@ -94,9 +99,8 @@ export class TaskCollector {
                 this.settings.removeExpression
             ),
             resetRegExp: this.tryCreateResetRegex(momentMatchString),
-            incompleteTaskRegExp: this.tryCreateIncompleteRegex(
-                this.settings.incompleteTaskValues
-            ),
+            incompleteTaskRegExp:
+                this.tryCreateIncompleteRegex(incompletedTasks),
             rightClickTaskMenu: rightClickTaskMenu,
             completedTasks: completedTasks,
             completedTaskRegExp: this.tryCreateCompleteRegex(completedTasks),
@@ -208,7 +212,7 @@ export class TaskCollector {
                     split[n] = this.completeTaskLine(split[n], mark);
                 } else {
                     console.debug(
-                        "TC: task already completed: %s",
+                        "TC: task already completed (%s): %s",
                         mark,
                         split[n]
                     );

--- a/test/generatedRegExp.test.ts
+++ b/test/generatedRegExp.test.ts
@@ -53,6 +53,21 @@ test('Complete > when included in incomplete pattern', () => {
     expect(tc.resetTaskLine('- [>] something', ' ')).toEqual('- [ ] something');
 });
 
+test('Test with empty incomplete pattern', () => {
+    const tc = new TaskCollector(new App());
+    config.incompleteTaskValues = '';
+    tc.updateSettings(config);
+
+    expect(tc.completeTaskLine('- [ ] something', 'x')).toEqual('- [x] something');
+    expect(tc.completeTaskLine('- [>] something', 'x')).toEqual('- [>] something'); // already "complete"
+    expect(tc.completeTaskLine('- [-] something', 'x')).toEqual('- [-] something'); // already "complete"
+    expect(tc.completeTaskLine('- [x] something', 'X')).toEqual('- [x] something'); // already "complete"
+    expect(tc.resetTaskLine('- [X] something', ' ')).toEqual('- [ ] something');
+    expect(tc.resetTaskLine('- [x] something', ' ')).toEqual('- [ ] something');
+    expect(tc.resetTaskLine('- [>] something', ' ')).toEqual('- [ ] something');
+    expect(tc.resetTaskLine('- [-] something', ' ')).toEqual('- [ ] something');
+});
+
 test('Match - when cancelled items are enabled', () => {
     const tc = new TaskCollector(new App());
     config.supportCanceledTasks = true;


### PR DESCRIPTION
Resolves #33.

The empty settings string prevented a generated regular expression from matching unmarked tasks.
