### PR TITLE
Fixes

### DIFF
--- a/src/@types/api.d.ts
+++ b/src/@types/api.d.ts
@@ -1,4 +1,4 @@
-export class API {
+export interface API {
     /**
      * Return completed task values as a string.
      * Will be "x", "xX", "x-", or "xX-"
@@ -27,5 +27,5 @@ export class API {
      *
      * Returns the selected "mark" (character) as a string.
      */
-     getMark(): Promise<string>;
+    getMark(): Promise<string>;
 }

--- a/src/taskcollector-Settings.ts
+++ b/src/taskcollector-Settings.ts
@@ -2,12 +2,13 @@ export interface TaskCollectorSettings {
     completedAreaHeader: string;
     removeExpression: string;
     appendDateFormat: string;
+    appendRemoveAllTasks: boolean;
     incompleteTaskValues: string;
     supportCanceledTasks: boolean;
+    previewOnClick: boolean;
     rightClickComplete: boolean;
     rightClickMark: boolean;
     rightClickMove: boolean;
-    rightClickReset: boolean; // ignored (old)
     rightClickResetTask: boolean;
     rightClickResetAll: boolean;
     rightClickToggleAll: boolean;
@@ -19,19 +20,19 @@ export const DEFAULT_SETTINGS: TaskCollectorSettings = {
     completedAreaHeader: "## Log",
     removeExpression: "",
     appendDateFormat: "",
+    appendRemoveAllTasks: false,
     incompleteTaskValues: " ",
-    supportCanceledTasks: false,
+    onlyLowercaseX: false,
+    supportCanceledTasks: true,
+    previewOnClick: false,
     rightClickComplete: false,
     rightClickMark: false,
     rightClickMove: false,
-    rightClickReset: false, // ignored (old)
     rightClickResetTask: false,
     rightClickResetAll: false,
     rightClickToggleAll: false,
     completedAreaRemoveCheckbox: false,
-    onlyLowercaseX: false,
 };
-
 export interface CompiledTasksSettings {
     removeRegExp: RegExp;
     resetRegExp: RegExp;
@@ -39,4 +40,5 @@ export interface CompiledTasksSettings {
     rightClickTaskMenu: boolean;
     completedTasks: string;
     completedTaskRegExp: RegExp;
+    registerHandlers: boolean;
 }

--- a/src/taskcollector-SettingsTab.ts
+++ b/src/taskcollector-SettingsTab.ts
@@ -31,7 +31,9 @@ export class TaskCollectorSettingsTab extends PluginSettingTab {
 
         new Setting(this.containerEl)
             .setName("Only support x for completed tasks")
-            .setDesc("Only use 'x' (lower case) to indicate completed tasks.")
+            .setDesc(
+                "Only use 'x' (lower case) to indicate completed tasks (hide X (upper case))."
+            )
             .addToggle((toggle) =>
                 toggle
                     .setValue(tempSettings.onlyLowercaseX)
@@ -76,7 +78,7 @@ export class TaskCollectorSettingsTab extends PluginSettingTab {
                             value.contains("X")
                         ) {
                             console.log(
-                                `Set of characters should not contain the marker for canceled tasks (X): ${value}`
+                                `Set of characters should not contain the marker for completed tasks (X): ${value}`
                             );
                         } else if (
                             tempSettings.supportCanceledTasks &&
@@ -100,7 +102,7 @@ export class TaskCollectorSettingsTab extends PluginSettingTab {
         this.containerEl.createEl("h2", { text: "Completing tasks" });
 
         this.containerEl.createEl("p", {
-            text: "Completed tasks, marked by 'x', 'X' (and optionally '-' for canceled items) gain special treatment based on the settings below.",
+            text: "Completed tasks (and optionally '-' for canceled items) gain special treatment based on the settings below.",
         });
 
         new Setting(this.containerEl)
@@ -152,6 +154,21 @@ export class TaskCollectorSettingsTab extends PluginSettingTab {
                     })
             );
 
+        new Setting(this.containerEl)
+            .setName("Apply these settings to all tasks")
+            .setDesc(
+                "Append and remove text as configured above when marking tasks with anything other than a space (to reset)."
+            )
+            .addToggle((toggle) =>
+                toggle
+                    .setValue(tempSettings.appendRemoveAllTasks)
+                    .onChange(async (value) => {
+                        tempSettings.appendRemoveAllTasks = value;
+                        this.taskCollector.updateSettings(tempSettings);
+                        await this.plugin.saveSettings();
+                    })
+            );
+
         this.containerEl.createEl("h2", { text: "Moving completed tasks" });
 
         new Setting(this.containerEl)
@@ -185,16 +202,35 @@ export class TaskCollectorSettingsTab extends PluginSettingTab {
                     })
             );
 
-        this.containerEl.createEl("h2", { text: "Right-click Menu items" });
+        this.containerEl.createEl("h2", {
+            text: "Marking items using menus",
+        });
 
         this.containerEl.createEl("p", {
             text: "Task Collector creates commands that can be bound to hotkeys or accessed using slash commands for marking tasks complete (or canceled) and resetting tasks to an incomplete state. The following settings add right click context menu items for those commands.",
         });
 
         new Setting(this.containerEl)
+            .setName(
+                "Preview / Live preview: Show the selection menu when a checkbox is clicked"
+            )
+            .setDesc(
+                "Display a panel that allows you to select (with mouse or keyboard) the value to assign when you click the task. The selected value will determine follow-on actions: complete, cancel, or reset."
+            )
+            .addToggle((toggle) =>
+                toggle
+                    .setValue(tempSettings.previewOnClick)
+                    .onChange(async (value) => {
+                        tempSettings.previewOnClick = value;
+                        this.taskCollector.updateSettings(tempSettings);
+                        await this.plugin.saveSettings();
+                    })
+            );
+
+        new Setting(this.containerEl)
             .setName("Add menu item for marking a task")
             .setDesc(
-                "Add an item to the right-click menu in edit mode to mark the task _on the current line (or within the current selection)_. This menu item will trigger a quick pop-up modal to select the desired mark value. The selected value will determine follow-on actions: complete, cancel, or reset."
+                "Add an item to the right-click menu in edit mode to mark the task on the current line (or within the current selection). This menu item will trigger a quick pop-up modal to select the desired mark value. The selected value will determine follow-on actions: complete, cancel, or reset."
             )
             .addToggle((toggle) =>
                 toggle
@@ -209,7 +245,7 @@ export class TaskCollectorSettingsTab extends PluginSettingTab {
         new Setting(this.containerEl)
             .setName("Add menu item for completing a task")
             .setDesc(
-                "Add an item to the right-click menu in edit mode to mark the task _on the current line (or within the current selection)_ complete. If canceled items are supported, an additional menu item will be added to mark selected tasks as canceled."
+                "Add an item to the right-click menu in edit mode to mark the task on the current line (or within the current selection) complete. If canceled items are supported, an additional menu item will be added to mark selected tasks as canceled."
             )
             .addToggle((toggle) =>
                 toggle
@@ -224,7 +260,7 @@ export class TaskCollectorSettingsTab extends PluginSettingTab {
         new Setting(this.containerEl)
             .setName("Add menu item for resetting a task")
             .setDesc(
-                "Add an item to the right-click menu in edit mode to reset the task _on the current line (or within the current selection)_."
+                "Add an item to the right-click menu in edit mode to reset the task on the current line (or within the current selection)."
             )
             .addToggle((toggle) =>
                 toggle
@@ -239,7 +275,7 @@ export class TaskCollectorSettingsTab extends PluginSettingTab {
         new Setting(this.containerEl)
             .setName("Add menu items for completing all tasks")
             .setDesc(
-                "Add an item to the right-click menu in edit mode to mark _all_ incomplete tasks in the current document complete."
+                "Add an item to the right-click menu in edit mode to mark all incomplete tasks in the current document complete."
             )
             .addToggle((toggle) =>
                 toggle
@@ -254,7 +290,7 @@ export class TaskCollectorSettingsTab extends PluginSettingTab {
         new Setting(this.containerEl)
             .setName("Add menu item for resetting all tasks")
             .setDesc(
-                "Add an item to the right-click menu to reset _all_ completed (or canceled) tasks."
+                "Add an item to the right-click menu to reset all completed (or canceled) tasks."
             )
             .addToggle((toggle) =>
                 toggle
@@ -269,7 +305,7 @@ export class TaskCollectorSettingsTab extends PluginSettingTab {
         new Setting(this.containerEl)
             .setName("Add menu item for moving all completed tasks")
             .setDesc(
-                "Add an item to the right-click menu to move _all_ completed (or canceled) tasks."
+                "Add an item to the right-click menu to move all completed (or canceled) tasks."
             )
             .addToggle((toggle) =>
                 toggle

--- a/src/taskcollector-TaskMarkModal.ts
+++ b/src/taskcollector-TaskMarkModal.ts
@@ -29,13 +29,14 @@ export class TaskMarkModal extends Modal {
         const selector = this.contentEl.createDiv(
             "taskcollector-selector markdown-preview-view"
         );
-        const completedTasks =
-            (this.taskCollector.settings.onlyLowercaseX ? "x" : "xX") +
-            (this.taskCollector.settings.supportCanceledTasks ? "-" : "");
 
         const completedList = selector.createEl("ul");
         completedList.addClass("contains-task-list");
-        this.addTaskValues(completedList, completedTasks, true);
+        this.addTaskValues(
+            completedList,
+            this.taskCollector.initSettings.completedTasks,
+            true
+        );
 
         const list = selector.createEl("ul");
         list.addClass("contains-task-list");

--- a/test/generatedRegExp.test.ts
+++ b/test/generatedRegExp.test.ts
@@ -46,10 +46,10 @@ test('Match specified removal patterns', () => {
     expect('- [x] something #task #todo').toMatch(tc.initSettings.removeRegExp);
     expect('- [x] something else').not.toMatch(tc.initSettings.removeRegExp);
 
-    expect(tc.completeTaskLine('- [ ] something #todo', 'x')).toEqual('- [x] something ');
-    expect(tc.completeTaskLine('- [>] something #todo', 'x')).toEqual('- [x] something ');
-    expect(tc.resetTaskLine('- [x] something #todo', ' ')).toEqual('- [ ] something #todo');
-    expect(tc.resetTaskLine('- [>] something #todo', ' ')).toEqual('- [ ] something #todo');
+    expect(tc.markTaskLine('- [ ] something #todo', 'x')).toEqual('- [x] something ');
+    expect(tc.markTaskLine('- [>] something #todo', 'x')).toEqual('- [x] something ');
+    expect(tc.markTaskLine('- [x] something #todo', ' ')).toEqual('- [ ] something #todo');
+    expect(tc.markTaskLine('- [>] something #todo', ' ')).toEqual('- [ ] something #todo');
 });
 
 describe('Set an append date', () => {
@@ -60,13 +60,14 @@ describe('Set an append date', () => {
 
         // raw settings
         expect('- [x] something 2021-08-24').toMatch(tc.initSettings.resetRegExp);
+        expect('- [x] something   2021-08-24  ').toMatch(tc.initSettings.resetRegExp); // extra whitespace shouldn't matter
 
         expect('- [x] something (2021-08-24)').not.toMatch(tc.initSettings.resetRegExp);
         expect('- [x] 2021-08-24 something else').not.toMatch(tc.initSettings.resetRegExp);
 
-        const completed = tc.completeTaskLine('- [ ] something #todo', 'x');
+        const completed = tc.markTaskLine('- [ ] something #todo', 'x');
         expect(completed).toMatch(tc.initSettings.resetRegExp);
-        expect(tc.resetTaskLine(completed)).toEqual('- [ ] something #todo');
+        expect(tc.markTaskLine(completed, ' ')).toEqual('- [ ] something #todo');
     });
 
     test('(YYYY-MM-DD) append string', () => {
@@ -79,9 +80,9 @@ describe('Set an append date', () => {
         expect('- [x] something 2021-08-24').not.toMatch(tc.initSettings.resetRegExp);
         expect('- [x] 2021-08-24 something else').not.toMatch(tc.initSettings.resetRegExp);
 
-        const completed = tc.completeTaskLine('- [ ] something #todo', 'x');
+        const completed = tc.markTaskLine('- [ ] something #todo', 'x');
         expect(completed).toMatch(tc.initSettings.resetRegExp);
-        expect(tc.resetTaskLine(completed)).toEqual('- [ ] something #todo');
+        expect(tc.markTaskLine(completed, ' ')).toEqual('- [ ] something #todo');
     });
 
     test('(D MMM, YYYY) append string', () => {
@@ -95,9 +96,9 @@ describe('Set an append date', () => {
         expect('- [x] 6 Oct, 2021, something else').not.toMatch(tc.initSettings.resetRegExp);
         expect('- [x] 2021-10-06 something else').not.toMatch(tc.initSettings.resetRegExp);
 
-        const completed = tc.completeTaskLine('- [ ] something #todo', 'x');
+        const completed = tc.markTaskLine('- [ ] something #todo', 'x');
         expect(completed).toMatch(tc.initSettings.resetRegExp);
-        expect(tc.resetTaskLine(completed)).toEqual('- [ ] something #todo');
+        expect(tc.markTaskLine(completed, ' ')).toEqual('- [ ] something #todo');
     });
 
     test('DD MMM, YYYY append string', () => {
@@ -112,9 +113,9 @@ describe('Set an append date', () => {
         expect('- [x] 6 Oct, 2021, something else').not.toMatch(tc.initSettings.resetRegExp);
         expect('- [x] 2021-10-06 something else').not.toMatch(tc.initSettings.resetRegExp);
 
-        const completed = tc.completeTaskLine('- [ ] something #todo', 'x');
+        const completed = tc.markTaskLine('- [ ] something #todo', 'x');
         expect(completed).toMatch(tc.initSettings.resetRegExp);
-        expect(tc.resetTaskLine(completed)).toEqual('- [ ] something #todo');
+        expect(tc.markTaskLine(completed, ' ')).toEqual('- [ ] something #todo');
     });
 
     test('[(completed on ]D MMM, YYYY[)] append string', () => {
@@ -129,9 +130,9 @@ describe('Set an append date', () => {
         expect('- [x] 6 Oct, 2021, something else').not.toMatch(tc.initSettings.resetRegExp);
         expect('- [x] 2021-10-06 something else').not.toMatch(tc.initSettings.resetRegExp);
 
-        const completed = tc.completeTaskLine('- [ ] something #todo', 'x');
+        const completed = tc.markTaskLine('- [ ] something #todo', 'x');
         expect(completed).toMatch(tc.initSettings.resetRegExp);
-        expect(tc.resetTaskLine(completed)).toEqual('- [ ] something #todo');
+        expect(tc.markTaskLine(completed, ' ')).toEqual('- [ ] something #todo');
     });
 
     test('[✅ ]YYYY-MM-DDTHH:mm append string', () => {
@@ -146,9 +147,9 @@ describe('Set an append date', () => {
         expect('- [x] 6 Oct, 2021, something else').not.toMatch(tc.initSettings.resetRegExp);
         expect('- [x] 2021-10-06 something else').not.toMatch(tc.initSettings.resetRegExp);
 
-        const completed = tc.completeTaskLine('- [ ] something #todo', 'x');
+        const completed = tc.markTaskLine('- [ ] something #todo', 'x');
         expect(completed).toMatch(tc.initSettings.resetRegExp);
-        expect(tc.resetTaskLine(completed)).toEqual('- [ ] something #todo');
+        expect(tc.markTaskLine(completed, ' ')).toEqual('- [ ] something #todo');
     });
 
     test('Dataview annotated string [completion::2021-08-15]', () => {
@@ -163,9 +164,9 @@ describe('Set an append date', () => {
         expect('- [x] 6 Oct, 2021, something else').not.toMatch(tc.initSettings.resetRegExp);
         expect('- [x] 2021-10-06 something else').not.toMatch(tc.initSettings.resetRegExp);
 
-        const completed = tc.completeTaskLine('- [ ] something #todo', 'x');
+        const completed = tc.markTaskLine('- [ ] something #todo', 'x');
         expect(completed).toMatch(tc.initSettings.resetRegExp);
-        expect(tc.resetTaskLine(completed)).toEqual('- [ ] something #todo');
+        expect(tc.markTaskLine(completed, ' ')).toEqual('- [ ] something #todo');
     });
 
     test('Correctly insert annotation ahead of block reference', () => {
@@ -179,10 +180,10 @@ describe('Set an append date', () => {
         expect('- [ ] something (6 Oct, 2021) ^your-ID-1').toMatch(tc.initSettings.incompleteTaskRegExp);
         expect('- [x] I finished this on [completion::2021-08-15] ^your-ID-1').toMatch(tc.initSettings.resetRegExp);
 
-        const completed = tc.completeTaskLine('- [ ] something #todo ^your-ID-1', 'x');
+        const completed = tc.markTaskLine('- [ ] something #todo ^your-ID-1', 'x');
         expect(completed).toMatch(/- \[x\] something #todo \[completion::\d+-\d+-\d+\] \^your-ID-1/);
         expect(completed).toMatch(tc.initSettings.resetRegExp);
-        expect(tc.resetTaskLine(completed)).toEqual('- [ ] something #todo ^your-ID-1');
+        expect(tc.markTaskLine(completed, ' ')).toEqual('- [ ] something #todo ^your-ID-1');
     });
 
     test('Preserve continuation with strict line-break', () => {
@@ -190,8 +191,65 @@ describe('Set an append date', () => {
         config.appendDateFormat = '[(]YYYY-MM-DD[)]';
         tc.updateSettings(config);
 
-        const completed = tc.completeTaskLine('- [ ] something  ', 'x');
+        const completed = tc.markTaskLine('- [ ] something  ', 'x');
         expect(completed).toMatch(/- \[x\] something  \(\d+-\d+-\d+\)  /);
     });
+
+    test('Preserve continuation with strict line-break across reset', () => {
+        const tc = new TaskCollector(new App());
+        config.appendDateFormat = '[(]YYYY-MM-DD[)]';
+        config.appendRemoveAllTasks = true;
+        config.incompleteTaskValues = '>';
+        tc.updateSettings(config);
+
+        const completed = tc.markTaskLine('- [ ] something  ', 'x');
+        expect(completed).toMatch(tc.initSettings.resetRegExp);
+        expect(completed).toMatch(/^- \[x\] something\s+\(\d+-\d+-\d+\)  $/);
+
+        const forwarded = tc.markTaskLine(completed, '>');
+        expect(forwarded).toMatch(tc.initSettings.resetRegExp);
+        expect(forwarded).toMatch(/^- \[>\] something\s+\(\d+-\d+-\d+\)  $/);
+
+        expect(tc.markTaskLine(forwarded, 'x')).toMatch(/^- \[x\] something\s+\(\d+-\d+-\d+\)  $/);
+    });
+});
+
+test('Apply text stripping/reset rules to all tasks', () => {
+    const tc = new TaskCollector(new App());
+    config.appendDateFormat = '[(]YYYY-MM-DD[)]';
+    config.removeExpression = "#(task|todo)";
+    config.incompleteTaskValues = '>';
+    config.appendRemoveAllTasks = true;
+    tc.updateSettings(config);
+
+    const completed = tc.markTaskLine('- [ ] something #todo', 'x');
+    expect(completed).not.toMatch(tc.initSettings.removeRegExp);
+    expect(completed).toMatch(tc.initSettings.resetRegExp);
+    expect(completed).toMatch(/^- \[x\] something \(\d+-\d+-\d+\)$/);
+
+    const changed = tc.markTaskLine('- [x] something #todo  (2022-04-26)', '>');
+    expect(changed).not.toMatch(tc.initSettings.removeRegExp);
+    expect(changed).toMatch(tc.initSettings.resetRegExp);
+    expect(changed).toMatch(/^- \[>\] something\s+\(\d+-\d+-\d+\)$/);
+
+    expect(tc.markTaskLine(changed, 'x')).toEqual(completed);
+    expect(tc.markTaskLine(changed, '-')).toMatch(/^- \[-\] something \(\d+-\d+-\d+\)$/);
+});
+
+test('Deal with unknown task value', () => {
+    const tc = new TaskCollector(new App());
+    config.appendDateFormat = '[(]YYYY-MM-DD[)]';
+    config.removeExpression = "#(task|todo)";
+    config.incompleteTaskValues = '>';
+    config.appendRemoveAllTasks = true;
+    tc.updateSettings(config);
+
+    const marked = tc.markTaskLine('- [ ] something #todo', 'm');
+    expect(marked).not.toMatch(tc.initSettings.removeRegExp);
+    expect(marked).toMatch(tc.initSettings.resetRegExp);
+    expect(marked).toMatch(/^- \[m\] something \(\d+-\d+-\d+\)$/);
+
+    // Don't know if this is complete (protected) or resettable. Do nothing.
+    expect(tc.markTaskLine(marked, 'x')).toEqual(marked);
 });
 

--- a/test/markTasks.test.ts
+++ b/test/markTasks.test.ts
@@ -27,16 +27,16 @@ test('Test default settings', () => {
 
     expect('- [x] ').toMatch(tc.initSettings.completedTaskRegExp);
     expect('- [X] ').toMatch(tc.initSettings.completedTaskRegExp);
-    expect('- [-] ').not.toMatch(tc.initSettings.completedTaskRegExp);
+    expect('- [-] ').toMatch(tc.initSettings.completedTaskRegExp);
 
-    expect(tc.completeTaskLine('- [ ] something', 'x')).toEqual('- [x] something');
-    expect(tc.completeTaskLine('- [>] something', 'x')).toEqual('- [>] something'); // already "complete"
-    expect(tc.completeTaskLine('- [-] something', 'x')).toEqual('- [-] something'); // already "complete"
-    expect(tc.completeTaskLine('- [x] something', 'X')).toEqual('- [x] something'); // already "complete"
-    expect(tc.resetTaskLine('- [X] something', ' ')).toEqual('- [ ] something');
-    expect(tc.resetTaskLine('- [x] something', ' ')).toEqual('- [ ] something');
-    expect(tc.resetTaskLine('- [>] something', ' ')).toEqual('- [ ] something');
-    expect(tc.resetTaskLine('- [-] something', ' ')).toEqual('- [ ] something');
+    expect(tc.markTaskLine('- [ ] something', 'x')).toEqual('- [x] something');
+    expect(tc.markTaskLine('- [>] something', 'x')).toEqual('- [>] something'); // "complete" (with something unknown)
+    expect(tc.markTaskLine('- [-] something', 'x')).toEqual('- [-] something'); // already "complete"
+    expect(tc.markTaskLine('- [x] something', 'X')).toEqual('- [x] something'); // already "complete"
+    expect(tc.markTaskLine('- [X] something', ' ')).toEqual('- [ ] something');
+    expect(tc.markTaskLine('- [x] something', ' ')).toEqual('- [ ] something');
+    expect(tc.markTaskLine('- [>] something', ' ')).toEqual('- [ ] something'); // always reset
+    expect(tc.markTaskLine('- [-] something', ' ')).toEqual('- [ ] something'); // always reset
 });
 
 test('Complete > when included in incomplete pattern', () => {
@@ -49,8 +49,8 @@ test('Complete > when included in incomplete pattern', () => {
 
     expect('- [>] ').toMatch(tc.initSettings.incompleteTaskRegExp);
 
-    expect(tc.completeTaskLine('- [>] something', 'x')).toEqual('- [x] something');
-    expect(tc.resetTaskLine('- [>] something', ' ')).toEqual('- [ ] something');
+    expect(tc.markTaskLine('- [>] something', 'x')).toEqual('- [x] something');
+    expect(tc.markTaskLine('- [>] something', ' ')).toEqual('- [ ] something');
 });
 
 test('- behaves like completed item when cancelled items are enabled', () => {
@@ -62,10 +62,10 @@ test('- behaves like completed item when cancelled items are enabled', () => {
     expect('- [-] ').not.toMatch(tc.initSettings.incompleteTaskRegExp);
     expect('- [-] ').toMatch(tc.initSettings.completedTaskRegExp);
 
-    expect(tc.completeTaskLine('- [ ] something', '-')).toEqual('- [-] something');
-    expect(tc.completeTaskLine('- [-] something', 'x')).toEqual('- [-] something');
-    expect(tc.completeTaskLine('- [x] something', '-')).toEqual('- [x] something');
-    expect(tc.resetTaskLine('- [-] something', ' ')).toEqual('- [ ] something');
+    expect(tc.markTaskLine('- [ ] something', '-')).toEqual('- [-] something');
+    expect(tc.markTaskLine('- [-] something', 'x')).toEqual('- [-] something');
+    expect(tc.markTaskLine('- [x] something', '-')).toEqual('- [x] something');
+    expect(tc.markTaskLine('- [-] something', ' ')).toEqual('- [ ] something');
 });
 
 test('Test with empty incomplete pattern', () => {
@@ -73,14 +73,14 @@ test('Test with empty incomplete pattern', () => {
     config.incompleteTaskValues = '';
     tc.updateSettings(config);
 
-    expect(tc.completeTaskLine('- [ ] something', 'x')).toEqual('- [x] something');
-    expect(tc.completeTaskLine('- [>] something', 'x')).toEqual('- [>] something'); // already "complete"
-    expect(tc.completeTaskLine('- [-] something', 'x')).toEqual('- [-] something'); // already "complete"
-    expect(tc.completeTaskLine('- [x] something', 'X')).toEqual('- [x] something'); // already "complete"
-    expect(tc.resetTaskLine('- [X] something', ' ')).toEqual('- [ ] something');
-    expect(tc.resetTaskLine('- [x] something', ' ')).toEqual('- [ ] something');
-    expect(tc.resetTaskLine('- [>] something', ' ')).toEqual('- [ ] something');
-    expect(tc.resetTaskLine('- [-] something', ' ')).toEqual('- [ ] something');
+    expect(tc.markTaskLine('- [ ] something', 'x')).toEqual('- [x] something');
+    expect(tc.markTaskLine('- [>] something', 'x')).toEqual('- [>] something'); // already "complete"
+    expect(tc.markTaskLine('- [-] something', 'x')).toEqual('- [-] something'); // already "complete"
+    expect(tc.markTaskLine('- [x] something', 'X')).toEqual('- [x] something'); // already "complete"
+    expect(tc.markTaskLine('- [X] something', ' ')).toEqual('- [ ] something');
+    expect(tc.markTaskLine('- [x] something', ' ')).toEqual('- [ ] something');
+    expect(tc.markTaskLine('- [>] something', ' ')).toEqual('- [ ] something');
+    expect(tc.markTaskLine('- [-] something', ' ')).toEqual('- [ ] something');
 });
 
 test('Correctly mark complete or incomplete items in a selection', () => {
@@ -106,9 +106,9 @@ test('Remove checkbox from line', () => {
     const canceled = '- [-] something [x]';
     const incomplete = '- [ ] something [x]';
     const listItem = '- something [x]';
-    expect(tc.removeCheckboxFromLine(completed)).toEqual(listItem);
-    expect(tc.removeCheckboxFromLine(canceled)).toEqual(listItem);
-    expect(tc.removeCheckboxFromLine(incomplete)).toEqual(listItem);
+    expect(tc.markTaskLine(completed, "Backspace")).toEqual(listItem);
+    expect(tc.markTaskLine(canceled, "Backspace")).toEqual(listItem);
+    expect(tc.markTaskLine(incomplete, "Backspace")).toEqual(listItem);
 });
 
 test('Create and Mark a normal list item', () => {
@@ -130,9 +130,9 @@ test('Mark tasks within a callout', () => {
     config.supportCanceledTasks = true;
     tc.updateSettings(config);
 
-    expect(tc.completeTaskLine('> - [ ] something', '-')).toEqual('> - [-] something');
-    expect(tc.resetTaskLine('> - [-] something', ' ')).toEqual('> - [ ] something');
+    expect(tc.markTaskLine('> - [ ] something', '-')).toEqual('> - [-] something');
+    expect(tc.markTaskLine('> - [-] something', ' ')).toEqual('> - [ ] something');
 
-    expect(tc.completeTaskLine('> > - [x] something', 'x')).toEqual('> > - [x] something');
-    expect(tc.resetTaskLine('> > - [x] something', ' ')).toEqual('> > - [ ] something');
+    expect(tc.markTaskLine('> > - [x] something', 'x')).toEqual('> > - [x] something');
+    expect(tc.markTaskLine('> > - [x] something', ' ')).toEqual('> > - [ ] something');
 });


### PR DESCRIPTION
- Add an option to apply append/reset rules to all task values (Resolves #36)
- Add an option to display the value selection modal when clicking checkboxes in Reading mode.  (Existing edit context menu items and keyboard shortcuts work for Live Preview)
